### PR TITLE
fix handling of plain keyword 'class' (#28)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -24,7 +24,7 @@ module.exports = {
   attrStringify({
     type, operator, head, classes, foot,
   }) {
-    return `${type}${operator}${head}${classes.join(' ')}${foot}`;
+    return `${type}${operator || ''}${head || ''}${classes.join(' ')}${foot || ''}`;
   },
 
 };

--- a/test/fixtures/source.css
+++ b/test/fixtures/source.css
@@ -78,3 +78,9 @@ div:not([class^="col-"]) {
 .hello:not([class*="left labeled"]) {
   border-radius: 3rem;
 }
+
+a:not([href]):not([class]),
+a:not([href]):not([class]):hover {
+  color: inherit;
+  text-decoration: none;
+}

--- a/test/fixtures/source.expected.css
+++ b/test/fixtures/source.expected.css
@@ -78,3 +78,9 @@ div:not([class^="prefix-col-"]) {
 .prefix-hello:not([class*="prefix-left prefix-labeled"]) {
   border-radius: 3rem;
 }
+
+a:not([href]):not([class]),
+a:not([href]):not([class]):hover {
+  color: inherit;
+  text-decoration: none;
+}

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -43,4 +43,11 @@ describe('utils.attrStringify()', () => {
 
     expect(result).toEqual('class^="col-"');
   });
+
+  test('should handle plain class', () => {
+    const attr = utils.parseAttrSelector({ type: 'attribute', content: 'class' });
+    const result = utils.attrStringify(attr);
+
+    expect(result).toEqual('class');
+  });
 });


### PR DESCRIPTION
Fixes https://github.com/marceloucker/postcss-prefixer/issues/28

I added some new test cases to confirm the behavior.

I don't know if this is the "best solution", but it was easy to implement without having to touch the really long RegEx.

I also tried using this solution for converting the full Bootstrap.css file, and the end result looked correct too.