### PR TITLE
feat: ignore file with @ignore comment at the top of the file

### DIFF
--- a/lib/prefixer.js
+++ b/lib/prefixer.js
@@ -62,6 +62,12 @@ const prefixer = (options) => {
   return {
     postcssPlugin: 'postcss-prefixer',
     Once(css) {
+      const first = css.nodes[0];
+
+
+      if (first && first.type === 'rule' && first.selector.trim() === '.ignore-postcss-prefixer-plugin') {
+        return;
+      }
       if (!prefix.length) return;
 
       css.walkRules((rule) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-prefixer",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "postcss plugin to prefix all css selector classes and ids",
   "main": "lib/prefixer.js",
   "engines": {

--- a/test/fixtures/ignore-file.css
+++ b/test/fixtures/ignore-file.css
@@ -1,0 +1,63 @@
+.ignore-postcss-prefixer-plugin {
+}
+
+html, body {
+  padding: 0;
+  margin: 0;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+#page {
+  overflow: hidden;
+}
+
+#page .page-header {
+  position: fixed
+}
+
+.btn {
+  display: flex;
+}
+
+.btn.btn--small {
+  display: flex;
+}
+
+.btn span {
+  display: inline;
+}
+
+.btn:hover, .btn:active, .btn:focus {
+  background-color: #fff;
+}
+
+.wrapper > .container {
+  display: flex;
+}
+
+.component .component--big {
+  width: 100%;
+}
+
+[class="icon-"],
+[class*="icon-"],
+[class^="icon-"],
+[class~="icon-"],
+[class|="icon-"],
+[class$="icon-"] {
+  display: inline;
+}
+
+span:not(.icon),
+button:not(.btn),
+div:not(.container),
+div:not([class^="col-"]) {
+  display: none;
+}
+
+.container[data-attr="some-value"] {
+  display: inline;
+}

--- a/test/prefixer.test.js
+++ b/test/prefixer.test.js
@@ -8,6 +8,7 @@ const DEFAULT_SOURCE_PATH = path.resolve(__dirname, 'fixtures/source.css');
 const DEFAULT_EXPECTED_PATH = path.resolve(__dirname, 'fixtures/source.expected.css');
 const IGNORE_SOURCE_PATH = path.resolve(__dirname, 'fixtures/ignore.css');
 const IGNORE_EXPECTED_PATH = path.resolve(__dirname, 'fixtures/ignore.expected.css');
+const IGNORE_FILE_SOURCE_PATH = path.resolve(__dirname, 'fixtures/ignore-file.css');
 
 const mocks = {
   default: {
@@ -17,6 +18,9 @@ const mocks = {
   ignore: {
     source: fs.readFileSync(IGNORE_SOURCE_PATH, 'utf8').trim(),
     expected: fs.readFileSync(IGNORE_EXPECTED_PATH, 'utf8').trim(),
+  },
+  ignoreFile: {
+    source: fs.readFileSync(IGNORE_FILE_SOURCE_PATH, 'utf8').trim(),
   },
 };
 
@@ -81,5 +85,13 @@ describe('Prefixer', () => {
       })).process(mocks.ignore.source);
 
     expect(css).toEqual(mocks.ignore.expected);
+  });
+
+  test('should not prefix file with @ignore comment', () => {
+    const { css } = postcss()
+      .use(postcssPrefixer())
+      .process(mocks.ignoreFile.source);
+
+    expect(css).toEqual(mocks.ignoreFile.source);
   });
 });


### PR DESCRIPTION
This is useful to exclude the whole files instead of using the ignore config
currently this can be used to mixed tailwind that needs a prefix but at the same time the project contains another scss
The idea did come from another plugin
https://github.com/RiadhAdrani/postcss-plugin-ignore-file